### PR TITLE
Fix compatibility with the latest sklearn version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo is missing the ability to convert isotonic regressions into pmml.
 This repo aims to solve that problem.
 
 ## Example
-A quick example can be found in `example_isotonicPMML.py` which uses the example (http://scikit-learn.org/stable/auto_examples/plot_isotonic_regression.html#example-plot-isotonic-regression-py) from sklearn to create an isotonic regression that can be converted to PMML.
+A quick example can be found in `example_isotonicPMML.py` which uses the example (https://scikit-learn.org/stable/auto_examples/miscellaneous/plot_isotonic_regression.html#sphx-glr-auto-examples-miscellaneous-plot-isotonic-regression-py) from sklearn to create an isotonic regression that can be converted to PMML.
 
 ## Production use.
 This repo solves the sklearn to pmml problem for isotonic regression, but does not solve the engine to run the code in, (say) a production environment.

--- a/example_isotonicPMML.py
+++ b/example_isotonicPMML.py
@@ -15,7 +15,8 @@ ir = IsotonicRegression()
 y_ = ir.fit_transform(x, y)
 
 # Export to PMML.
-isotonic2pmml.topmml(isotonic = ir,
-                     datafield_name = 'x',
-                     targetfield_name = 'y',
-                     outputfile = 'test.pmml')
+isotonic2pmml.topmml(x,
+                     y_,
+                     datafield_name='x',
+                     targetfield_name='y',
+                     outputfile='test.pmml')

--- a/example_isotonicPMML.py
+++ b/example_isotonicPMML.py
@@ -7,7 +7,7 @@ from sklearn.utils import check_random_state
 n = 100
 x = np.arange(n)
 rs = check_random_state(0)
-y = rs.randint(-50, 50, size=(n,)) + 50. * np.log(1 + np.arange(n))
+y = rs.randint(-50, 50, size=(n,)) + 50. * np.log1p(np.arange(n))
 
 ###############################################################################
 # Fit IsotonicRegression

--- a/isotonic2pmml.py
+++ b/isotonic2pmml.py
@@ -4,42 +4,48 @@ from io import BytesIO
 from xml.dom import minidom
 
 
-def topmml(isotonic, datafield_name, targetfield_name, outputfile):
+def topmml(xs, ys, datafield_name, targetfield_name, outputfile):
     # Header
-    root = ET.Element('PMML', {'xmlns':'http://www.dmg.org/PMML-4_2','version':'4.2'})
-    header = ET.SubElement(root,'Header')
-    ET.SubElement(header,'Application', {'name' : 'isotonic2pmml', 'version' : '1.0'})
-    timestamp = ET.SubElement(header,'Timestamp')
+    root = ET.Element(
+        'PMML', {'xmlns': 'http://www.dmg.org/PMML-4_2', 'version': '4.2'})
+    header = ET.SubElement(root, 'Header')
+    ET.SubElement(header, 'Application', {
+                  'name': 'isotonic2pmml', 'version': '1.0'})
+    timestamp = ET.SubElement(header, 'Timestamp')
     timestamp.text = datetime.utcnow().isoformat()
 
     # Data dictionary
     datadictionary = ET.SubElement(root, 'DataDictionary')
     ET.SubElement(datadictionary, 'DataField',
-                  {'name' : datafield_name, 'optype' : 'continuous', 'dataType' : 'double'})
+                  {'name': datafield_name, 'optype': 'continuous', 'dataType': 'double'})
     ET.SubElement(datadictionary, 'DataField',
-                  {'name' : targetfield_name, 'optype' : 'continuous', 'dataType' : 'double'})
+                  {'name': targetfield_name, 'optype': 'continuous', 'dataType': 'double'})
 
     # Regression model
-    regressionmodel = ET.SubElement(root,'RegressionModel',
-                                    { 'modelName' : 'Isotonic regression', 'functionName' : 'regression',
-                                      'algorithmName' : 'linearRegression'})
+    regressionmodel = ET.SubElement(root, 'RegressionModel',
+                                    {'modelName': 'Isotonic regression', 'functionName': 'regression',
+                                     'algorithmName': 'linearRegression'})
     miningschema = ET.SubElement(regressionmodel, 'MiningSchema')
-    ET.SubElement(miningschema, 'MiningField', { 'name' : datafield_name })
-    ET.SubElement(miningschema, 'MiningField', { 'name' : targetfield_name, 'usageType' : 'target' })
+    ET.SubElement(miningschema, 'MiningField', {'name': datafield_name})
+    ET.SubElement(miningschema, 'MiningField', {
+                  'name': targetfield_name, 'usageType': 'target'})
     # Isotonic transformation
-    transformationdictionary = ET.SubElement(regressionmodel, 'LocalTransformations')
+    transformationdictionary = ET.SubElement(
+        regressionmodel, 'LocalTransformations')
     derivedfield = ET.SubElement(transformationdictionary, 'DerivedField',
-                                 { 'dataType' : 'double', 'name' : 'isotonic', 'optype' :'continuous'})
-    normcontinuous = ET.SubElement(derivedfield, 'NormContinuous', { 'field' : datafield_name})
+                                 {'dataType': 'double', 'name': 'isotonic', 'optype': 'continuous'})
+    normcontinuous = ET.SubElement(derivedfield, 'NormContinuous', {
+                                   'field': datafield_name})
     idx = 0
-    for x in isotonic.X_:
+    for x in xs:
         ET.SubElement(normcontinuous, 'LinearNorm',
-                      { 'orig' : '%.8f' % x, 'norm' : '%.8f' % isotonic.y_[idx]})
+                      {'orig': '%.8f' % x, 'norm': '%.8f' % ys[idx]})
         idx = idx + 1
     # 'Equal' regression table
-    regressiontable = ET.SubElement(regressionmodel, 'RegressionTable', {'intercept' : '0.0'})
+    regressiontable = ET.SubElement(
+        regressionmodel, 'RegressionTable', {'intercept': '0.0'})
     ET.SubElement(regressiontable, 'NumericPredictor',
-                  {'name' : 'isotonic', 'exponent' : '1', 'coefficient' : '1.0' } )
+                  {'name': 'isotonic', 'exponent': '1', 'coefficient': '1.0'})
 
     # Pretty printing
     tree = ET.ElementTree(root)


### PR DESCRIPTION
Hi,
This is quite an old repo and, in the meanwhile, the syntax for IsotonicRegression from sklearn has changed a bit. Namely, it's no longer possible to retrieve the original arguments (`X_`) and fitted values (`y_`) from the regression object, so they have to be passed to the converter directly.